### PR TITLE
Add a `describe` wrapper with an injected `aptos` client instance

### DIFF
--- a/examples/js-esm-node-app/tests/my-first-test.js
+++ b/examples/js-esm-node-app/tests/my-first-test.js
@@ -1,13 +1,13 @@
 import { expect } from "chai";
-import { generateTestAccount, publishPackage } from "@aptos-labs/workspace";
-import { AptosConfig, Network, Aptos } from "@aptos-labs/ts-sdk";
-
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
+import {
+  generateTestAccount,
+  publishPackage,
+  describe,
+} from "@aptos-labs/workspace";
 
 let publisherAccount;
 
-describe("my first test", () => {
+describe("my first test", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/examples/js-esm-node-app/tests/todoList.js
+++ b/examples/js-esm-node-app/tests/todoList.js
@@ -1,17 +1,17 @@
 import { expect } from "chai";
-import { generateTestAccount, publishPackage } from "@aptos-labs/workspace";
-import { AptosConfig, Network, Aptos } from "@aptos-labs/ts-sdk";
+import {
+  generateTestAccount,
+  publishPackage,
+  describe,
+} from "@aptos-labs/workspace";
 import { addNewListTransaction } from "../entry-functions/addNewList.js";
 import { addNewTaskTransaction } from "../entry-functions/addNewTask.js";
 import { completeTaskTransaction } from "../entry-functions/completeTask.js";
 
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
-
 let publisherAccount;
 let todoListCreator;
 
-describe("todoList", () => {
+describe("todoList", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/examples/js-node-app/tests/my-first-test.js
+++ b/examples/js-node-app/tests/my-first-test.js
@@ -2,15 +2,12 @@ const expect = require("chai").expect;
 const {
   generateTestAccount,
   publishPackage,
+  describe,
 } = require("@aptos-labs/workspace");
-const { AptosConfig, Network, Aptos } = require("@aptos-labs/ts-sdk");
-
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
 
 let publisherAccount;
 
-describe("my first test", () => {
+describe("my first test", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/examples/js-node-app/tests/todoList.js
+++ b/examples/js-node-app/tests/todoList.js
@@ -2,19 +2,16 @@ const expect = require("chai").expect;
 const {
   generateTestAccount,
   publishPackage,
+  describe,
 } = require("@aptos-labs/workspace");
-const { AptosConfig, Network, Aptos } = require("@aptos-labs/ts-sdk");
 const { addNewListTransaction } = require("../entry-functions/addNewList");
 const { addNewTaskTransaction } = require("../entry-functions/addNewTask");
 const { completeTaskTransaction } = require("../entry-functions/completeTask");
 
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
-
 let publisherAccount;
 let todoListCreator;
 
-describe("todoList", () => {
+describe("todoList", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/examples/ts-nextjs-app/tests/my-first-test.ts
+++ b/examples/ts-nextjs-app/tests/my-first-test.ts
@@ -1,18 +1,14 @@
 import { expect } from "chai";
-import { generateTestAccount, publishPackage } from "@aptos-labs/workspace";
 import {
-  AptosConfig,
-  Network,
-  Aptos,
-  Ed25519Account,
-} from "@aptos-labs/ts-sdk";
-
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
+  generateTestAccount,
+  publishPackage,
+  describe,
+} from "@aptos-labs/workspace";
+import { Ed25519Account } from "@aptos-labs/ts-sdk";
 
 let publisherAccount: Ed25519Account;
 
-describe("my first test", () => {
+describe("my first test", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/examples/ts-nextjs-app/tests/todoList.ts
+++ b/examples/ts-nextjs-app/tests/todoList.ts
@@ -1,22 +1,18 @@
 import { expect } from "chai";
-import { generateTestAccount, publishPackage } from "@aptos-labs/workspace";
 import {
-  AptosConfig,
-  Network,
-  Aptos,
-  Ed25519Account,
-} from "@aptos-labs/ts-sdk";
+  generateTestAccount,
+  publishPackage,
+  describe,
+} from "@aptos-labs/workspace";
+import { Ed25519Account } from "@aptos-labs/ts-sdk";
 import { addNewListTransaction } from "@/entry-functions/addNewList";
 import { addNewTaskTransaction } from "@/entry-functions/addNewTask";
 import { completeTaskTransaction } from "@/entry-functions/completeTask";
 
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
-
 let publisherAccount: Ed25519Account;
 let todoListCreator: Ed25519Account;
 
-describe("todoList", () => {
+describe("todoList", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/examples/ts-node-app/tests/my-first-test.ts
+++ b/examples/ts-node-app/tests/my-first-test.ts
@@ -1,18 +1,14 @@
 import { expect } from "chai";
-import { generateTestAccount, publishPackage } from "@aptos-labs/workspace";
 import {
-  AptosConfig,
-  Network,
-  Aptos,
-  Ed25519Account,
-} from "@aptos-labs/ts-sdk";
-
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
+  generateTestAccount,
+  publishPackage,
+  describe,
+} from "@aptos-labs/workspace";
+import { Ed25519Account } from "@aptos-labs/ts-sdk";
 
 let publisherAccount: Ed25519Account;
 
-describe("my first test", () => {
+describe("my first test", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/examples/ts-node-app/tests/todoList.ts
+++ b/examples/ts-node-app/tests/todoList.ts
@@ -1,22 +1,18 @@
 import { expect } from "chai";
-import { generateTestAccount, publishPackage } from "@aptos-labs/workspace";
 import {
-  AptosConfig,
-  Network,
-  Aptos,
-  Ed25519Account,
-} from "@aptos-labs/ts-sdk";
+  generateTestAccount,
+  publishPackage,
+  describe,
+} from "@aptos-labs/workspace";
+import { Ed25519Account } from "@aptos-labs/ts-sdk";
 import { addNewListTransaction } from "../entry-functions/addNewList";
 import { addNewTaskTransaction } from "../entry-functions/addNewTask";
 import { completeTaskTransaction } from "../entry-functions/completeTask";
 
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
-
 let publisherAccount: Ed25519Account;
 let todoListCreator: Ed25519Account;
 
-describe("todoList", () => {
+describe("todoList", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/examples/ts-vite-dapp/tests/my-first-test.ts
+++ b/examples/ts-vite-dapp/tests/my-first-test.ts
@@ -1,18 +1,10 @@
 import { expect } from "chai";
-import { generateTestAccount, publishPackage } from "@aptos-labs/workspace";
-import {
-  AptosConfig,
-  Network,
-  Aptos,
-  Ed25519Account,
-} from "@aptos-labs/ts-sdk";
-
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
+import { generateTestAccount, publishPackage, describe } from "@aptos-labs/workspace";
+import { Ed25519Account } from "@aptos-labs/ts-sdk";
 
 let publisherAccount: Ed25519Account;
 
-describe("my first test", () => {
+describe("my first test", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/examples/ts-vite-dapp/tests/todoList.ts
+++ b/examples/ts-vite-dapp/tests/todoList.ts
@@ -1,17 +1,14 @@
 import { expect } from "chai";
-import { generateTestAccount, publishPackage } from "@aptos-labs/workspace";
-import { AptosConfig, Network, Aptos, Ed25519Account } from "@aptos-labs/ts-sdk";
+import { generateTestAccount, publishPackage, describe } from "@aptos-labs/workspace";
+import { Ed25519Account } from "@aptos-labs/ts-sdk";
 import { addNewListTransaction } from "@/entry-functions/addNewList";
 import { addNewTaskTransaction } from "@/entry-functions/addNewTask";
 import { completeTaskTransaction } from "@/entry-functions/completeTask";
 
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
-
 let publisherAccount: Ed25519Account;
 let todoListCreator: Ed25519Account;
 
-describe("todoList", () => {
+describe("todoList", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/workspace/sample-project/js-esm/tests/my-first-test.js
+++ b/workspace/sample-project/js-esm/tests/my-first-test.js
@@ -1,13 +1,13 @@
 import { expect } from "chai";
-import { generateTestAccount, publishPackage } from "@aptos-labs/workspace";
-import { AptosConfig, Network, Aptos } from "@aptos-labs/ts-sdk";
-
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
+import {
+  generateTestAccount,
+  publishPackage,
+  describe,
+} from "@aptos-labs/workspace";
 
 let publisherAccount;
 
-describe("my first test", () => {
+describe("my first test", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/workspace/sample-project/js/tests/my-first-test.js
+++ b/workspace/sample-project/js/tests/my-first-test.js
@@ -2,15 +2,12 @@ const expect = require("chai").expect;
 const {
   generateTestAccount,
   publishPackage,
+  describe,
 } = require("@aptos-labs/workspace");
-const { AptosConfig, Network, Aptos } = require("@aptos-labs/ts-sdk");
-
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
 
 let publisherAccount;
 
-describe("my first test", () => {
+describe("my first test", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/workspace/sample-project/ts/tests/my-first-test.ts
+++ b/workspace/sample-project/ts/tests/my-first-test.ts
@@ -1,18 +1,14 @@
 import { expect } from "chai";
-import { generateTestAccount, publishPackage } from "@aptos-labs/workspace";
 import {
-  AptosConfig,
-  Network,
-  Aptos,
-  Ed25519Account,
-} from "@aptos-labs/ts-sdk";
-
-const aptosConfig = new AptosConfig({ network: Network.LOCAL });
-const aptos = new Aptos(aptosConfig);
+  generateTestAccount,
+  publishPackage,
+  describe,
+} from "@aptos-labs/workspace";
+import { Ed25519Account } from "@aptos-labs/ts-sdk";
 
 let publisherAccount: Ed25519Account;
 
-describe("my first test", () => {
+describe("my first test", (aptos) => {
   before(function (done) {
     (async () => {
       publisherAccount = await generateTestAccount();

--- a/workspace/src/external/api.ts
+++ b/workspace/src/external/api.ts
@@ -7,6 +7,7 @@ import {
 } from "@aptos-labs/ts-sdk";
 import { publishPackageTask } from "../tasks/publish";
 import { compilePackageTask } from "../tasks/compile";
+import { describe as MochaDescribe } from "mocha";
 
 const aptosConfig = new AptosConfig({ network: Network.LOCAL });
 const aptos = new Aptos(aptosConfig);
@@ -33,4 +34,21 @@ export const publishPackage = async (args: {
   const { publisher, namedAddresses } = args;
   await compilePackageTask(namedAddresses);
   await publishPackageTask({ aptos, publisher });
+};
+
+/**
+ * A `describe` block runner to be used in tests with an injected `aptos` client
+ *
+ * @param description The decribe block description
+ * @param block A callback function to run
+ */
+export const describe = (
+  description: string,
+  block: (aptos: Aptos) => void
+) => {
+  // Call the original mocha describe with the modified block
+  MochaDescribe(description, () => {
+    // Execute the original test block
+    block(aptos);
+  });
 };


### PR DESCRIPTION
Exposing a workspace describe block for developers to use as the describe test block in their tests.
This way, developers can focus on writing their tests, and the framework automatically handles the aptos client and other setup processes in the background. 

It also aligns with other testing frameworks approach like:
- [Vitest](https://vitest.dev/guide/#writing-tests)
- [Playwright](https://playwright.dev/docs/writing-tests#first-test)
