### PR TITLE
Publish move package under an object address

### DIFF
--- a/examples/js-esm-node-app/package-lock.json
+++ b/examples/js-esm-node-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aptos-labs/ts-sdk": "^1.26.0"
+        "@aptos-labs/ts-sdk": "^1.29.1"
       },
       "devDependencies": {
         "@aptos-labs/workspace": "file:../../workspace",
@@ -21,6 +21,7 @@
       }
     },
     "../../workspace": {
+      "name": "@aptos-labs/workspace",
       "version": "0.0.2",
       "dev": true,
       "license": "Apache-2.0",
@@ -29,6 +30,7 @@
         "find-up": "^2.1.0",
         "fs-extra": "^7.0.1",
         "mocha": "^10.7.0",
+        "prompts": "^2.4.2",
         "tree-kill": "1.2.2",
         "tsconfig-paths": "^4.2.0"
       },
@@ -36,7 +38,7 @@
         "aptos-workspace": "dist/internal/cli.js"
       },
       "devDependencies": {
-        "@aptos-labs/ts-sdk": "^1.26.0",
+        "@aptos-labs/ts-sdk": "^1.29.1",
         "@types/chai": "^4.2.0",
         "@types/find-up": "^2.1.1",
         "@types/fs-extra": "^5.1.0",
@@ -54,7 +56,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@aptos-labs/ts-sdk": ">=1.26.0",
+        "@aptos-labs/ts-sdk": ">=1.29.1",
         "@types/chai": "^4.2.0",
         "@types/mocha": "^10.0.7",
         "@types/node": "^20.14.11",
@@ -89,9 +91,9 @@
       }
     },
     "node_modules/@aptos-labs/ts-sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.27.1.tgz",
-      "integrity": "sha512-QS4BlivXQy/uJgXcNOfXNjv8l+MSd+qQ256mY/Jc6iaWbfn69nRYh6chjSyLot4fHA49QxlZlWh1mJLlfNdtow==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.29.1.tgz",
+      "integrity": "sha512-cQsXBTbSG5XzrulzEgSMc7BPUl6jw257b248nBDYkUv6tMHkWlxuFKF6F2l+6Z8/buNIQKNPZnaZKT26DjVKug==",
       "dependencies": {
         "@aptos-labs/aptos-cli": "^0.2.0",
         "@aptos-labs/aptos-client": "^0.1.1",

--- a/examples/js-esm-node-app/package.json
+++ b/examples/js-esm-node-app/package.json
@@ -19,7 +19,7 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.26.0"
+    "@aptos-labs/ts-sdk": "^1.29.1"
   },
   "devDependencies": {
     "@aptos-labs/workspace": "file:../../workspace",

--- a/examples/js-esm-node-app/tests/my-first-test.js
+++ b/examples/js-esm-node-app/tests/my-first-test.js
@@ -5,24 +5,26 @@ import {
   describe,
 } from "@aptos-labs/workspace";
 
-let publisherAccount;
+let objectAddress;
 
 describe("my first test", (aptos) => {
-  before(function (done) {
-    (async () => {
-      publisherAccount = await generateTestAccount();
-      await publishPackage({
-        publisher: publisherAccount,
-        namedAddresses: {
-          module_addr: publisherAccount.accountAddress.toString(),
-        },
-      });
-    })().then(done);
+  before(async function () {
+    const publisherAccount = await generateTestAccount();
+    // publish the package, getting back the package pbject address
+    const { packageObjectAddress } = await publishPackage({
+      publisher: publisherAccount,
+      addressName: "module_addr",
+      namedAddresses: {
+        module_addr: publisherAccount.accountAddress,
+      },
+    });
+    // set the object address to the package object address
+    objectAddress = packageObjectAddress;
   });
 
   it("it publishes the contract under the correct address", async () => {
     const accountModule = await aptos.getAccountModules({
-      accountAddress: publisherAccount.accountAddress,
+      accountAddress: objectAddress,
     });
     expect(accountModule).to.have.length.at.least(1);
   });

--- a/examples/js-esm-node-app/tests/todoList.js
+++ b/examples/js-esm-node-app/tests/todoList.js
@@ -8,25 +8,25 @@ import { addNewListTransaction } from "../entry-functions/addNewList.js";
 import { addNewTaskTransaction } from "../entry-functions/addNewTask.js";
 import { completeTaskTransaction } from "../entry-functions/completeTask.js";
 
-let publisherAccount;
+let objectAddress;
 let todoListCreator;
 
 describe("todoList", (aptos) => {
-  before(function (done) {
-    (async () => {
-      publisherAccount = await generateTestAccount();
-      await publishPackage({
-        publisher: publisherAccount,
-        namedAddresses: {
-          module_addr: publisherAccount.accountAddress.toString(),
-        },
-      });
-    })().then(done);
+  before(async function () {
+    const publisherAccount = await generateTestAccount();
+    const { packageObjectAddress } = await publishPackage({
+      publisher: publisherAccount,
+      addressName: "module_addr",
+      namedAddresses: {
+        module_addr: publisherAccount.accountAddress,
+      },
+    });
+    objectAddress = packageObjectAddress;
   });
 
   it("it publishes the contract under the correct address", async () => {
     const accountModule = await aptos.getAccountModule({
-      accountAddress: publisherAccount.accountAddress,
+      accountAddress: objectAddress,
       moduleName: "todolist",
     });
     expect(accountModule).to.not.undefined;
@@ -34,9 +34,7 @@ describe("todoList", (aptos) => {
 
   it("it creates a new list", async () => {
     todoListCreator = await generateTestAccount();
-    const addNewListTxn = await addNewListTransaction(
-      publisherAccount.accountAddress.toString()
-    );
+    const addNewListTxn = await addNewListTransaction(objectAddress);
 
     const transaction = await aptos.transaction.build.simple({
       sender: todoListCreator.accountAddress,
@@ -56,7 +54,7 @@ describe("todoList", (aptos) => {
 
     const todoListResource = await aptos.getAccountResource({
       accountAddress: todoListCreator.accountAddress,
-      resourceType: `${publisherAccount.accountAddress.toString()}::todolist::TodoList`,
+      resourceType: `${objectAddress}::todolist::TodoList`,
     });
 
     expect(todoListResource).to.not.undefined;
@@ -65,7 +63,7 @@ describe("todoList", (aptos) => {
   it("it creates a new task", async () => {
     const addNewListTxn = await addNewTaskTransaction(
       "test task",
-      publisherAccount.accountAddress.toString()
+      objectAddress
     );
 
     const transaction = await aptos.transaction.build.simple({
@@ -86,10 +84,7 @@ describe("todoList", (aptos) => {
   });
 
   it("it marks task as completed", async () => {
-    const addNewListTxn = await completeTaskTransaction(
-      "1",
-      publisherAccount.accountAddress.toString()
-    );
+    const addNewListTxn = await completeTaskTransaction("1", objectAddress);
 
     const transaction = await aptos.transaction.build.simple({
       sender: todoListCreator.accountAddress,

--- a/examples/js-node-app/package-lock.json
+++ b/examples/js-node-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aptos-labs/ts-sdk": "^1.26.0"
+        "@aptos-labs/ts-sdk": "^1.29.1"
       },
       "devDependencies": {
         "@aptos-labs/workspace": "file:../../workspace",
@@ -21,6 +21,7 @@
       }
     },
     "../../workspace": {
+      "name": "@aptos-labs/workspace",
       "version": "0.0.2",
       "dev": true,
       "license": "Apache-2.0",
@@ -29,6 +30,7 @@
         "find-up": "^2.1.0",
         "fs-extra": "^7.0.1",
         "mocha": "^10.7.0",
+        "prompts": "^2.4.2",
         "tree-kill": "1.2.2",
         "tsconfig-paths": "^4.2.0"
       },
@@ -36,7 +38,7 @@
         "aptos-workspace": "dist/internal/cli.js"
       },
       "devDependencies": {
-        "@aptos-labs/ts-sdk": "^1.26.0",
+        "@aptos-labs/ts-sdk": "^1.29.1",
         "@types/chai": "^4.2.0",
         "@types/find-up": "^2.1.1",
         "@types/fs-extra": "^5.1.0",
@@ -54,7 +56,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@aptos-labs/ts-sdk": ">=1.26.0",
+        "@aptos-labs/ts-sdk": ">=1.29.1",
         "@types/chai": "^4.2.0",
         "@types/mocha": "^10.0.7",
         "@types/node": "^20.14.11",
@@ -89,9 +91,9 @@
       }
     },
     "node_modules/@aptos-labs/ts-sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.27.1.tgz",
-      "integrity": "sha512-QS4BlivXQy/uJgXcNOfXNjv8l+MSd+qQ256mY/Jc6iaWbfn69nRYh6chjSyLot4fHA49QxlZlWh1mJLlfNdtow==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.29.1.tgz",
+      "integrity": "sha512-cQsXBTbSG5XzrulzEgSMc7BPUl6jw257b248nBDYkUv6tMHkWlxuFKF6F2l+6Z8/buNIQKNPZnaZKT26DjVKug==",
       "dependencies": {
         "@aptos-labs/aptos-cli": "^0.2.0",
         "@aptos-labs/aptos-client": "^0.1.1",

--- a/examples/js-node-app/package.json
+++ b/examples/js-node-app/package.json
@@ -18,7 +18,7 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.26.0"
+    "@aptos-labs/ts-sdk": "^1.29.1"
   },
   "devDependencies": {
     "@aptos-labs/workspace": "file:../../workspace",

--- a/examples/js-node-app/tests/my-first-test.js
+++ b/examples/js-node-app/tests/my-first-test.js
@@ -5,24 +5,24 @@ const {
   describe,
 } = require("@aptos-labs/workspace");
 
-let publisherAccount;
+let objectAddress;
 
 describe("my first test", (aptos) => {
-  before(function (done) {
-    (async () => {
-      publisherAccount = await generateTestAccount();
-      await publishPackage({
-        publisher: publisherAccount,
-        namedAddresses: {
-          module_addr: publisherAccount.accountAddress.toString(),
-        },
-      });
-    })().then(done);
+  before(async function () {
+    const publisherAccount = await generateTestAccount();
+    const { packageObjectAddress } = await publishPackage({
+      publisher: publisherAccount,
+      addressName: "module_addr",
+      namedAddresses: {
+        module_addr: publisherAccount.accountAddress,
+      },
+    });
+    objectAddress = packageObjectAddress;
   });
 
   it("it publishes the contract under the correct address", async () => {
     const accountModule = await aptos.getAccountModules({
-      accountAddress: publisherAccount.accountAddress,
+      accountAddress: objectAddress,
     });
     expect(accountModule).to.have.length.at.least(1);
   });

--- a/examples/js-node-app/tests/todoList.js
+++ b/examples/js-node-app/tests/todoList.js
@@ -8,25 +8,25 @@ const { addNewListTransaction } = require("../entry-functions/addNewList");
 const { addNewTaskTransaction } = require("../entry-functions/addNewTask");
 const { completeTaskTransaction } = require("../entry-functions/completeTask");
 
-let publisherAccount;
+let objectAddress;
 let todoListCreator;
 
 describe("todoList", (aptos) => {
-  before(function (done) {
-    (async () => {
-      publisherAccount = await generateTestAccount();
-      await publishPackage({
-        publisher: publisherAccount,
-        namedAddresses: {
-          module_addr: publisherAccount.accountAddress.toString(),
-        },
-      });
-    })().then(done);
+  before(async function () {
+    const publisherAccount = await generateTestAccount();
+    const { packageObjectAddress } = await publishPackage({
+      publisher: publisherAccount,
+      addressName: "module_addr",
+      namedAddresses: {
+        module_addr: publisherAccount.accountAddress,
+      },
+    });
+    objectAddress = packageObjectAddress;
   });
 
   it("it publishes the contract under the correct address", async () => {
     const accountModule = await aptos.getAccountModule({
-      accountAddress: publisherAccount.accountAddress,
+      accountAddress: objectAddress,
       moduleName: "todolist",
     });
     expect(accountModule).to.not.undefined;
@@ -34,9 +34,7 @@ describe("todoList", (aptos) => {
 
   it("it creates a new list", async () => {
     todoListCreator = await generateTestAccount();
-    const addNewListTxn = await addNewListTransaction(
-      publisherAccount.accountAddress.toString()
-    );
+    const addNewListTxn = await addNewListTransaction(objectAddress);
 
     const transaction = await aptos.transaction.build.simple({
       sender: todoListCreator.accountAddress,
@@ -56,7 +54,7 @@ describe("todoList", (aptos) => {
 
     const todoListResource = await aptos.getAccountResource({
       accountAddress: todoListCreator.accountAddress,
-      resourceType: `${publisherAccount.accountAddress.toString()}::todolist::TodoList`,
+      resourceType: `${objectAddress}::todolist::TodoList`,
     });
 
     expect(todoListResource).to.not.undefined;
@@ -65,7 +63,7 @@ describe("todoList", (aptos) => {
   it("it creates a new task", async () => {
     const addNewListTxn = await addNewTaskTransaction(
       "test task",
-      publisherAccount.accountAddress.toString()
+      objectAddress
     );
 
     const transaction = await aptos.transaction.build.simple({
@@ -86,10 +84,7 @@ describe("todoList", (aptos) => {
   });
 
   it("it marks task as completed", async () => {
-    const addNewListTxn = await completeTaskTransaction(
-      "1",
-      publisherAccount.accountAddress.toString()
-    );
+    const addNewListTxn = await completeTaskTransaction("1", objectAddress);
 
     const transaction = await aptos.transaction.build.simple({
       sender: todoListCreator.accountAddress,

--- a/examples/ts-nextjs-app/package-lock.json
+++ b/examples/ts-nextjs-app/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ts-next-app",
       "version": "0.0.0",
       "dependencies": {
-        "@aptos-labs/ts-sdk": "^1.26.0",
+        "@aptos-labs/ts-sdk": "^1.29.1",
         "@aptos-labs/wallet-adapter-react": "^3.5.0",
         "next": "14.2.5",
         "react": "^18",
@@ -27,6 +27,7 @@
       }
     },
     "../../workspace": {
+      "name": "@aptos-labs/workspace",
       "version": "0.0.2",
       "dev": true,
       "license": "Apache-2.0",
@@ -35,6 +36,7 @@
         "find-up": "^2.1.0",
         "fs-extra": "^7.0.1",
         "mocha": "^10.7.0",
+        "prompts": "^2.4.2",
         "tree-kill": "1.2.2",
         "tsconfig-paths": "^4.2.0"
       },
@@ -42,7 +44,7 @@
         "aptos-workspace": "dist/internal/cli.js"
       },
       "devDependencies": {
-        "@aptos-labs/ts-sdk": "^1.26.0",
+        "@aptos-labs/ts-sdk": "^1.29.1",
         "@types/chai": "^4.2.0",
         "@types/find-up": "^2.1.1",
         "@types/fs-extra": "^5.1.0",
@@ -60,7 +62,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@aptos-labs/ts-sdk": ">=1.26.0",
+        "@aptos-labs/ts-sdk": ">=1.29.1",
         "@types/chai": "^4.2.0",
         "@types/mocha": "^10.0.7",
         "@types/node": "^20.14.11",
@@ -95,9 +97,9 @@
       }
     },
     "node_modules/@aptos-labs/ts-sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.27.1.tgz",
-      "integrity": "sha512-QS4BlivXQy/uJgXcNOfXNjv8l+MSd+qQ256mY/Jc6iaWbfn69nRYh6chjSyLot4fHA49QxlZlWh1mJLlfNdtow==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.29.1.tgz",
+      "integrity": "sha512-cQsXBTbSG5XzrulzEgSMc7BPUl6jw257b248nBDYkUv6tMHkWlxuFKF6F2l+6Z8/buNIQKNPZnaZKT26DjVKug==",
       "dependencies": {
         "@aptos-labs/aptos-cli": "^0.2.0",
         "@aptos-labs/aptos-client": "^0.1.1",

--- a/examples/ts-nextjs-app/package.json
+++ b/examples/ts-nextjs-app/package.json
@@ -14,7 +14,7 @@
     "react": "^18",
     "react-dom": "^18",
     "next": "14.2.5",
-    "@aptos-labs/ts-sdk": "^1.26.0",
+    "@aptos-labs/ts-sdk": "^1.29.1",
     "@aptos-labs/wallet-adapter-react": "^3.5.0"
   },
   "devDependencies": {

--- a/examples/ts-nextjs-app/tests/my-first-test.ts
+++ b/examples/ts-nextjs-app/tests/my-first-test.ts
@@ -4,26 +4,27 @@ import {
   publishPackage,
   describe,
 } from "@aptos-labs/workspace";
-import { Ed25519Account } from "@aptos-labs/ts-sdk";
 
-let publisherAccount: Ed25519Account;
+let objectAddress: string;
 
 describe("my first test", (aptos) => {
-  before(function (done) {
-    (async () => {
-      publisherAccount = await generateTestAccount();
-      await publishPackage({
-        publisher: publisherAccount,
-        namedAddresses: {
-          module_addr: publisherAccount.accountAddress.toString(),
-        },
-      });
-    })().then(done);
+  before(async function () {
+    const publisherAccount = await generateTestAccount();
+    // publish the package, getting back the package pbject address
+    const { packageObjectAddress } = await publishPackage({
+      publisher: publisherAccount,
+      addressName: "module_addr",
+      namedAddresses: {
+        module_addr: publisherAccount.accountAddress,
+      },
+    });
+    // set the object address to the package object address
+    objectAddress = packageObjectAddress;
   });
 
   it("it publishes the contract under the correct address", async () => {
     const accountModule = await aptos.getAccountModules({
-      accountAddress: publisherAccount.accountAddress,
+      accountAddress: objectAddress,
     });
     expect(accountModule).to.have.length.at.least(1);
   });

--- a/examples/ts-nextjs-app/tests/todoList.ts
+++ b/examples/ts-nextjs-app/tests/todoList.ts
@@ -9,25 +9,25 @@ import { addNewListTransaction } from "@/entry-functions/addNewList";
 import { addNewTaskTransaction } from "@/entry-functions/addNewTask";
 import { completeTaskTransaction } from "@/entry-functions/completeTask";
 
-let publisherAccount: Ed25519Account;
+let objectAddress: string;
 let todoListCreator: Ed25519Account;
 
 describe("todoList", (aptos) => {
-  before(function (done) {
-    (async () => {
-      publisherAccount = await generateTestAccount();
-      await publishPackage({
-        publisher: publisherAccount,
-        namedAddresses: {
-          module_addr: publisherAccount.accountAddress.toString(),
-        },
-      });
-    })().then(done);
+  before(async function () {
+    const publisherAccount = await generateTestAccount();
+    const { packageObjectAddress } = await publishPackage({
+      publisher: publisherAccount,
+      addressName: "module_addr",
+      namedAddresses: {
+        module_addr: publisherAccount.accountAddress,
+      },
+    });
+    objectAddress = packageObjectAddress;
   });
 
   it("it publishes the contract under the correct address", async () => {
     const accountModule = await aptos.getAccountModule({
-      accountAddress: publisherAccount.accountAddress,
+      accountAddress: objectAddress,
       moduleName: "todolist",
     });
     expect(accountModule).to.not.undefined;
@@ -35,9 +35,7 @@ describe("todoList", (aptos) => {
 
   it("it creates a new list", async () => {
     todoListCreator = await generateTestAccount();
-    const addNewListTxn = await addNewListTransaction(
-      publisherAccount.accountAddress.toString()
-    );
+    const addNewListTxn = await addNewListTransaction(objectAddress);
 
     const transaction = await aptos.transaction.build.simple({
       sender: todoListCreator.accountAddress,
@@ -57,7 +55,7 @@ describe("todoList", (aptos) => {
 
     const todoListResource = await aptos.getAccountResource({
       accountAddress: todoListCreator.accountAddress,
-      resourceType: `${publisherAccount.accountAddress.toString()}::todolist::TodoList`,
+      resourceType: `${objectAddress}::todolist::TodoList`,
     });
 
     expect(todoListResource).to.not.undefined;
@@ -66,7 +64,7 @@ describe("todoList", (aptos) => {
   it("it creates a new task", async () => {
     const addNewListTxn = await addNewTaskTransaction(
       "test task",
-      publisherAccount.accountAddress.toString()
+      objectAddress
     );
 
     const transaction = await aptos.transaction.build.simple({
@@ -87,10 +85,7 @@ describe("todoList", (aptos) => {
   });
 
   it("it marks task as completed", async () => {
-    const addNewListTxn = await completeTaskTransaction(
-      "1",
-      publisherAccount.accountAddress.toString()
-    );
+    const addNewListTxn = await completeTaskTransaction("1", objectAddress);
 
     const transaction = await aptos.transaction.build.simple({
       sender: todoListCreator.accountAddress,

--- a/examples/ts-node-app/package-lock.json
+++ b/examples/ts-node-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aptos-labs/ts-sdk": "^1.26.0"
+        "@aptos-labs/ts-sdk": "^1.29.1"
       },
       "devDependencies": {
         "@aptos-labs/workspace": "file:../../workspace",
@@ -28,7 +28,6 @@
       }
     },
     "../../workspace": {
-      "name": "@aptos-labs/workspace",
       "version": "0.0.2",
       "dev": true,
       "license": "Apache-2.0",
@@ -45,7 +44,7 @@
         "aptos-workspace": "dist/internal/cli.js"
       },
       "devDependencies": {
-        "@aptos-labs/ts-sdk": "^1.26.0",
+        "@aptos-labs/ts-sdk": "^1.29.1",
         "@types/chai": "^4.2.0",
         "@types/find-up": "^2.1.1",
         "@types/fs-extra": "^5.1.0",
@@ -63,7 +62,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@aptos-labs/ts-sdk": ">=1.26.0",
+        "@aptos-labs/ts-sdk": ">=1.29.1",
         "@types/chai": "^4.2.0",
         "@types/mocha": "^10.0.7",
         "@types/node": "^20.14.11",
@@ -98,9 +97,9 @@
       }
     },
     "node_modules/@aptos-labs/ts-sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.27.1.tgz",
-      "integrity": "sha512-QS4BlivXQy/uJgXcNOfXNjv8l+MSd+qQ256mY/Jc6iaWbfn69nRYh6chjSyLot4fHA49QxlZlWh1mJLlfNdtow==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.29.1.tgz",
+      "integrity": "sha512-cQsXBTbSG5XzrulzEgSMc7BPUl6jw257b248nBDYkUv6tMHkWlxuFKF6F2l+6Z8/buNIQKNPZnaZKT26DjVKug==",
       "dependencies": {
         "@aptos-labs/aptos-cli": "^0.2.0",
         "@aptos-labs/aptos-client": "^0.1.1",
@@ -150,9 +149,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
-      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -204,22 +203,22 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.2",
+        "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
@@ -295,22 +294,25 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.5.0.tgz",
-      "integrity": "sha512-J5EKamIHnKPyClwVrzmaf5wSdQXgdHcPZIZLu3bwnbeCx8/7NPK5q2ZBWF+5FvYGByjiQQsJYX6jfgB2wDPn3A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.5.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -352,44 +354,33 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
-      "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.5.0.tgz",
+      "integrity": "sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==",
       "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32/node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/curves": "~1.6.0",
+        "@noble/hashes": "~1.5.0",
+        "@scure/base": "~1.1.7"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
+      "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
       "dependencies": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
+        "@noble/hashes": "~1.5.0",
+        "@scure/base": "~1.1.8"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -453,9 +444,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.19.tgz",
-      "integrity": "sha512-2hHHvQBVE2FiSK4eN0Br6snX9MtolHaTo/batnLjlGRhoQzlCL61iVpxoqO7SfFyOw+P/pwv+0zNHzKoGWz9Cw==",
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
       "dev": true
     },
     "node_modules/@types/http-cache-semantics": {
@@ -472,15 +463,15 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.7.tgz",
-      "integrity": "sha512-GN8yJ1mNTcFcah/wKEFIJckJx9iJLoMSzWcfRRuxz/Jk+U6KQNnml+etbtxFK8lPjzOw3zp4Ha/kjSst9fsHYw==",
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.9.tgz",
+      "integrity": "sha512-sicdRoWtYevwxjOHNMPTl3vSfJM6oyW8o1wXeI7uww6b6xHg8eBznQDNSGBCDJmsE8UMxP05JgZRtsKbTqt//Q==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.16.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.1.tgz",
-      "integrity": "sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==",
+      "version": "20.16.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.11.tgz",
+      "integrity": "sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -706,9 +697,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
-      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.11.0"
@@ -976,12 +967,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1117,16 +1108,17 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.0",
-        "@humanwhocodes/config-array": "^0.11.14",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -1401,9 +1393,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
@@ -1875,9 +1867,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "node_modules/natural-compare": {
@@ -2064,9 +2056,9 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -2380,9 +2372,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/examples/ts-node-app/package.json
+++ b/examples/ts-node-app/package.json
@@ -18,7 +18,7 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.26.0"
+    "@aptos-labs/ts-sdk": "^1.29.1"
   },
   "devDependencies": {
     "@aptos-labs/workspace": "file:../../workspace",

--- a/examples/ts-node-app/tests/my-first-test.ts
+++ b/examples/ts-node-app/tests/my-first-test.ts
@@ -4,27 +4,30 @@ import {
   publishPackage,
   describe,
 } from "@aptos-labs/workspace";
-import { Ed25519Account } from "@aptos-labs/ts-sdk";
 
-let publisherAccount: Ed25519Account;
+let objectAddress: string;
 
 describe("my first test", (aptos) => {
-  before(function (done) {
-    (async () => {
-      publisherAccount = await generateTestAccount();
-      await publishPackage({
-        publisher: publisherAccount,
-        namedAddresses: {
-          module_addr: publisherAccount.accountAddress.toString(),
-        },
-      });
-    })().then(done);
+  before(async function () {
+    const publisherAccount = await generateTestAccount();
+    // publish the package, getting back the package pbject address
+    const { packageObjectAddress } = await publishPackage({
+      publisher: publisherAccount,
+      addressName: "module_addr",
+      namedAddresses: {
+        module_addr: publisherAccount.accountAddress,
+      },
+    });
+    // set the object address to the package object address
+    objectAddress = packageObjectAddress;
   });
 
   it("it publishes the contract under the correct address", async () => {
+    // get the object account modules
     const accountModule = await aptos.getAccountModules({
-      accountAddress: publisherAccount.accountAddress,
+      accountAddress: objectAddress,
     });
+    // expect the account modules to have at least one module
     expect(accountModule).to.have.length.at.least(1);
   });
 });

--- a/examples/ts-vite-dapp/package.json
+++ b/examples/ts-vite-dapp/package.json
@@ -20,7 +20,7 @@
     "fmt": "npm run _fmt -- --write"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^1.26.0",
+    "@aptos-labs/ts-sdk": "^1.29.1",
     "@aptos-labs/wallet-adapter-react": "^3.5.0",
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-collapsible": "^1.1.0",

--- a/examples/ts-vite-dapp/tests/my-first-test.ts
+++ b/examples/ts-vite-dapp/tests/my-first-test.ts
@@ -1,25 +1,26 @@
 import { expect } from "chai";
 import { generateTestAccount, publishPackage, describe } from "@aptos-labs/workspace";
-import { Ed25519Account } from "@aptos-labs/ts-sdk";
 
-let publisherAccount: Ed25519Account;
+let objectAddress: string;
 
 describe("my first test", (aptos) => {
-  before(function (done) {
-    (async () => {
-      publisherAccount = await generateTestAccount();
-      await publishPackage({
-        publisher: publisherAccount,
-        namedAddresses: {
-          module_addr: publisherAccount.accountAddress.toString(),
-        },
-      });
-    })().then(done);
+  before(async function () {
+    const publisherAccount = await generateTestAccount();
+    // publish the package, getting back the package pbject address
+    const { packageObjectAddress } = await publishPackage({
+      publisher: publisherAccount,
+      addressName: "module_addr",
+      namedAddresses: {
+        module_addr: publisherAccount.accountAddress,
+      },
+    });
+    // set the object address to the package object address
+    objectAddress = packageObjectAddress;
   });
 
   it("it publishes the contract under the correct address", async () => {
     const accountModule = await aptos.getAccountModules({
-      accountAddress: publisherAccount.accountAddress,
+      accountAddress: objectAddress,
     });
     expect(accountModule).to.have.length.at.least(1);
   });

--- a/examples/ts-vite-dapp/tests/todoList.ts
+++ b/examples/ts-vite-dapp/tests/todoList.ts
@@ -5,25 +5,25 @@ import { addNewListTransaction } from "@/entry-functions/addNewList";
 import { addNewTaskTransaction } from "@/entry-functions/addNewTask";
 import { completeTaskTransaction } from "@/entry-functions/completeTask";
 
-let publisherAccount: Ed25519Account;
+let objectAddress: string;
 let todoListCreator: Ed25519Account;
 
 describe("todoList", (aptos) => {
-  before(function (done) {
-    (async () => {
-      publisherAccount = await generateTestAccount();
-      await publishPackage({
-        publisher: publisherAccount,
-        namedAddresses: {
-          module_addr: publisherAccount.accountAddress.toString(),
-        },
-      });
-    })().then(done);
+  before(async function () {
+    const publisherAccount = await generateTestAccount();
+    const { packageObjectAddress } = await publishPackage({
+      publisher: publisherAccount,
+      addressName: "module_addr",
+      namedAddresses: {
+        module_addr: publisherAccount.accountAddress,
+      },
+    });
+    objectAddress = packageObjectAddress;
   });
 
   it("it publishes the contract under the correct address", async () => {
     const accountModule = await aptos.getAccountModule({
-      accountAddress: publisherAccount.accountAddress,
+      accountAddress: objectAddress,
       moduleName: "todolist",
     });
     expect(accountModule).to.not.undefined;
@@ -31,7 +31,7 @@ describe("todoList", (aptos) => {
 
   it("it creates a new list", async () => {
     todoListCreator = await generateTestAccount();
-    const addNewListTxn = await addNewListTransaction(publisherAccount.accountAddress.toString());
+    const addNewListTxn = await addNewListTransaction(objectAddress);
 
     const transaction = await aptos.transaction.build.simple({
       sender: todoListCreator.accountAddress,
@@ -51,14 +51,14 @@ describe("todoList", (aptos) => {
 
     const todoListResource = await aptos.getAccountResource({
       accountAddress: todoListCreator.accountAddress,
-      resourceType: `${publisherAccount.accountAddress.toString()}::todolist::TodoList`,
+      resourceType: `${objectAddress}::todolist::TodoList`,
     });
 
     expect(todoListResource).to.not.undefined;
   });
 
   it("it creates a new task", async () => {
-    const addNewListTxn = await addNewTaskTransaction("test task", publisherAccount.accountAddress.toString());
+    const addNewListTxn = await addNewTaskTransaction("test task", objectAddress);
 
     const transaction = await aptos.transaction.build.simple({
       sender: todoListCreator.accountAddress,
@@ -78,7 +78,7 @@ describe("todoList", (aptos) => {
   });
 
   it("it marks task as completed", async () => {
-    const addNewListTxn = await completeTaskTransaction("1", publisherAccount.accountAddress.toString());
+    const addNewListTxn = await completeTaskTransaction("1", objectAddress);
 
     const transaction = await aptos.transaction.build.simple({
       sender: todoListCreator.accountAddress,

--- a/workspace/package-lock.json
+++ b/workspace/package-lock.json
@@ -21,7 +21,7 @@
         "aptos-workspace": "dist/internal/cli.js"
       },
       "devDependencies": {
-        "@aptos-labs/ts-sdk": "^1.26.0",
+        "@aptos-labs/ts-sdk": "^1.29.1",
         "@types/chai": "^4.2.0",
         "@types/find-up": "^2.1.1",
         "@types/fs-extra": "^5.1.0",
@@ -39,7 +39,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@aptos-labs/ts-sdk": ">=1.26.0",
+        "@aptos-labs/ts-sdk": ">=1.29.1",
         "@types/chai": "^4.2.0",
         "@types/mocha": "^10.0.7",
         "@types/node": "^20.14.11",
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@aptos-labs/ts-sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.27.1.tgz",
-      "integrity": "sha512-QS4BlivXQy/uJgXcNOfXNjv8l+MSd+qQ256mY/Jc6iaWbfn69nRYh6chjSyLot4fHA49QxlZlWh1mJLlfNdtow==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.29.1.tgz",
+      "integrity": "sha512-cQsXBTbSG5XzrulzEgSMc7BPUl6jw257b248nBDYkUv6tMHkWlxuFKF6F2l+6Z8/buNIQKNPZnaZKT26DjVKug==",
       "dev": true,
       "dependencies": {
         "@aptos-labs/aptos-cli": "^0.2.0",
@@ -509,9 +509,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
-      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -563,22 +563,22 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.2",
+        "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
@@ -646,9 +646,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -783,24 +783,27 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.5.0.tgz",
-      "integrity": "sha512-J5EKamIHnKPyClwVrzmaf5wSdQXgdHcPZIZLu3bwnbeCx8/7NPK5q2ZBWF+5FvYGByjiQQsJYX6jfgB2wDPn3A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
       "dev": true,
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.5.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
       "dev": true,
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -852,9 +855,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.1.tgz",
-      "integrity": "sha512-2thheikVEuU7ZxFXubPDOtspKn1x0yqaYQwvALVtEcvFhMifPADBrgRPyHV0TF3b+9BgvgjgagVyvA/UqPZHmg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
+      "integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
       "cpu": [
         "arm"
       ],
@@ -865,9 +868,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.21.1.tgz",
-      "integrity": "sha512-t1lLYn4V9WgnIFHXy1d2Di/7gyzBWS8G5pQSXdZqfrdCGTwi1VasRMSS81DTYb+avDs/Zz4A6dzERki5oRYz1g==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
+      "integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
       "cpu": [
         "arm64"
       ],
@@ -878,9 +881,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.21.1.tgz",
-      "integrity": "sha512-AH/wNWSEEHvs6t4iJ3RANxW5ZCK3fUnmf0gyMxWCesY1AlUj8jY7GC+rQE4wd3gwmZ9XDOpL0kcFnCjtN7FXlA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
+      "integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
       "cpu": [
         "arm64"
       ],
@@ -891,9 +894,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.21.1.tgz",
-      "integrity": "sha512-dO0BIz/+5ZdkLZrVgQrDdW7m2RkrLwYTh2YMFG9IpBtlC1x1NPNSXkfczhZieOlOLEqgXOFH3wYHB7PmBtf+Bg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
+      "integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
       "cpu": [
         "x64"
       ],
@@ -904,9 +907,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.21.1.tgz",
-      "integrity": "sha512-sWWgdQ1fq+XKrlda8PsMCfut8caFwZBmhYeoehJ05FdI0YZXk6ZyUjWLrIgbR/VgiGycrFKMMgp7eJ69HOF2pQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
+      "integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
       "cpu": [
         "arm"
       ],
@@ -917,9 +920,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.21.1.tgz",
-      "integrity": "sha512-9OIiSuj5EsYQlmwhmFRA0LRO0dRRjdCVZA3hnmZe1rEwRk11Jy3ECGGq3a7RrVEZ0/pCsYWx8jG3IvcrJ6RCew==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
+      "integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
       "cpu": [
         "arm"
       ],
@@ -930,9 +933,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.21.1.tgz",
-      "integrity": "sha512-0kuAkRK4MeIUbzQYu63NrJmfoUVicajoRAL1bpwdYIYRcs57iyIV9NLcuyDyDXE2GiZCL4uhKSYAnyWpjZkWow==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
+      "integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
       "cpu": [
         "arm64"
       ],
@@ -943,9 +946,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.21.1.tgz",
-      "integrity": "sha512-/6dYC9fZtfEY0vozpc5bx1RP4VrtEOhNQGb0HwvYNwXD1BBbwQ5cKIbUVVU7G2d5WRE90NfB922elN8ASXAJEA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
+      "integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
       "cpu": [
         "arm64"
       ],
@@ -956,9 +959,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.21.1.tgz",
-      "integrity": "sha512-ltUWy+sHeAh3YZ91NUsV4Xg3uBXAlscQe8ZOXRCVAKLsivGuJsrkawYPUEyCV3DYa9urgJugMLn8Z3Z/6CeyRQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
+      "integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
       "cpu": [
         "ppc64"
       ],
@@ -969,9 +972,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.21.1.tgz",
-      "integrity": "sha512-BggMndzI7Tlv4/abrgLwa/dxNEMn2gC61DCLrTzw8LkpSKel4o+O+gtjbnkevZ18SKkeN3ihRGPuBxjaetWzWg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
+      "integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
       "cpu": [
         "riscv64"
       ],
@@ -982,9 +985,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.21.1.tgz",
-      "integrity": "sha512-z/9rtlGd/OMv+gb1mNSjElasMf9yXusAxnRDrBaYB+eS1shFm6/4/xDH1SAISO5729fFKUkJ88TkGPRUh8WSAA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
+      "integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
       "cpu": [
         "s390x"
       ],
@@ -995,9 +998,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.21.1.tgz",
-      "integrity": "sha512-kXQVcWqDcDKw0S2E0TmhlTLlUgAmMVqPrJZR+KpH/1ZaZhLSl23GZpQVmawBQGVhyP5WXIsIQ/zqbDBBYmxm5w==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
+      "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
       "cpu": [
         "x64"
       ],
@@ -1008,9 +1011,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.21.1.tgz",
-      "integrity": "sha512-CbFv/WMQsSdl+bpX6rVbzR4kAjSSBuDgCqb1l4J68UYsQNalz5wOqLGYj4ZI0thGpyX5kc+LLZ9CL+kpqDovZA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
+      "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
       "cpu": [
         "x64"
       ],
@@ -1021,9 +1024,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.21.1.tgz",
-      "integrity": "sha512-3Q3brDgA86gHXWHklrwdREKIrIbxC0ZgU8lwpj0eEKGBQH+31uPqr0P2v11pn0tSIxHvcdOWxa4j+YvLNx1i6g==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
+      "integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
       "cpu": [
         "arm64"
       ],
@@ -1034,9 +1037,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.21.1.tgz",
-      "integrity": "sha512-tNg+jJcKR3Uwe4L0/wY3Ro0H+u3nrb04+tcq1GSYzBEmKLeOQF2emk1whxlzNqb6MMrQ2JOcQEpuuiPLyRcSIw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
+      "integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
       "cpu": [
         "ia32"
       ],
@@ -1047,9 +1050,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.1.tgz",
-      "integrity": "sha512-xGiIH95H1zU7naUyTKEyOA/I0aexNMUdO9qRv0bLKN3qu25bBdrxZHqA3PTJ24YNN/GdMzG4xkDcd/GvjuhfLg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
+      "integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
       "cpu": [
         "x64"
       ],
@@ -1060,48 +1063,36 @@
       ]
     },
     "node_modules/@scure/base": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
-      "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "dev": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.5.0.tgz",
+      "integrity": "sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==",
       "dev": true,
       "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32/node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
-      "dev": true,
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/curves": "~1.6.0",
+        "@noble/hashes": "~1.5.0",
+        "@scure/base": "~1.1.7"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
+      "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
       "dev": true,
       "dependencies": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
+        "@noble/hashes": "~1.5.0",
+        "@scure/base": "~1.1.8"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1168,15 +1159,15 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.19.tgz",
-      "integrity": "sha512-2hHHvQBVE2FiSK4eN0Br6snX9MtolHaTo/batnLjlGRhoQzlCL61iVpxoqO7SfFyOw+P/pwv+0zNHzKoGWz9Cw==",
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
       "dev": true
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
     "node_modules/@types/find-up": {
@@ -1210,15 +1201,15 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.7.tgz",
-      "integrity": "sha512-GN8yJ1mNTcFcah/wKEFIJckJx9iJLoMSzWcfRRuxz/Jk+U6KQNnml+etbtxFK8lPjzOw3zp4Ha/kjSst9fsHYw==",
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.9.tgz",
+      "integrity": "sha512-sicdRoWtYevwxjOHNMPTl3vSfJM6oyW8o1wXeI7uww6b6xHg8eBznQDNSGBCDJmsE8UMxP05JgZRtsKbTqt//Q==",
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.16.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.1.tgz",
-      "integrity": "sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==",
+      "version": "20.16.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.11.tgz",
+      "integrity": "sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -1446,9 +1437,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
-      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.11.0"
@@ -1868,12 +1859,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2053,9 +2044,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -2074,16 +2065,17 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.0",
-        "@humanwhocodes/config-array": "^0.11.14",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -2512,9 +2504,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "dev": true,
       "funding": [
         {
@@ -3342,12 +3334,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mocha/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
     "node_modules/mocha/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3403,9 +3389,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "node_modules/mz": {
@@ -3548,9 +3534,9 @@
       }
     },
     "node_modules/package-json-from-dist": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
-      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
     },
     "node_modules/parent-module": {
@@ -3626,9 +3612,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -3743,9 +3729,9 @@
       "dev": true
     },
     "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
       "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -3926,12 +3912,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.1.tgz",
-      "integrity": "sha512-ZnYyKvscThhgd3M5+Qt3pmhO4jIRR5RGzaSovB6Q7rGNrK5cUncrtLmcTTJVSdcKXyZjW8X8MB0JMSuH9bcAJg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
+      "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
       "dev": true,
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.6"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3941,22 +3927,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.21.1",
-        "@rollup/rollup-android-arm64": "4.21.1",
-        "@rollup/rollup-darwin-arm64": "4.21.1",
-        "@rollup/rollup-darwin-x64": "4.21.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.21.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.21.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.21.1",
-        "@rollup/rollup-linux-arm64-musl": "4.21.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.21.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.21.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.21.1",
-        "@rollup/rollup-linux-x64-gnu": "4.21.1",
-        "@rollup/rollup-linux-x64-musl": "4.21.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.21.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.21.1",
-        "@rollup/rollup-win32-x64-msvc": "4.21.1",
+        "@rollup/rollup-android-arm-eabi": "4.24.0",
+        "@rollup/rollup-android-arm64": "4.24.0",
+        "@rollup/rollup-darwin-arm64": "4.24.0",
+        "@rollup/rollup-darwin-x64": "4.24.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.24.0",
+        "@rollup/rollup-linux-arm64-musl": "4.24.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-musl": "4.24.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.24.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.24.0",
+        "@rollup/rollup-win32-x64-msvc": "4.24.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -4250,6 +4236,45 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.9.tgz",
+      "integrity": "sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.4.0",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.0.tgz",
+      "integrity": "sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==",
+      "dev": true,
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4363,9 +4388,9 @@
       }
     },
     "node_modules/tsup": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.2.4.tgz",
-      "integrity": "sha512-akpCPePnBnC/CXgRrcy72ZSntgIEUa1jN0oJbbvpALWKNOz1B7aM+UVDWGRGIO/T/PZugAESWDJUAb5FD48o8Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.3.0.tgz",
+      "integrity": "sha512-ALscEeyS03IomcuNdFdc0YWGVIkwH1Ws7nfTbAPuoILvEV2hpGQAY72LIOjglGo4ShWpZfpBqP/jpQVCzqYQag==",
       "dev": true,
       "dependencies": {
         "bundle-require": "^5.0.0",
@@ -4375,7 +4400,6 @@
         "debug": "^4.3.5",
         "esbuild": "^0.23.0",
         "execa": "^5.1.1",
-        "globby": "^11.1.0",
         "joycon": "^3.1.1",
         "picocolors": "^1.0.1",
         "postcss-load-config": "^6.0.1",
@@ -4383,6 +4407,7 @@
         "rollup": "^4.19.0",
         "source-map": "0.8.0-beta.0",
         "sucrase": "^3.35.0",
+        "tinyglobby": "^0.2.1",
         "tree-kill": "^1.2.2"
       },
       "bin": {
@@ -4456,9 +4481,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/workspace/package.json
+++ b/workspace/package.json
@@ -30,7 +30,7 @@
     "tsconfig-paths": "^4.2.0"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": ">=1.26.0",
+    "@aptos-labs/ts-sdk": ">=1.29.1",
     "@types/chai": "^4.2.0",
     "@types/mocha": "^10.0.7",
     "@types/node": "^20.14.11",
@@ -44,7 +44,7 @@
     }
   },
   "devDependencies": {
-    "@aptos-labs/ts-sdk": "^1.26.0",
+    "@aptos-labs/ts-sdk": "^1.29.1",
     "@types/chai": "^4.2.0",
     "@types/find-up": "^2.1.1",
     "@types/fs-extra": "^5.1.0",

--- a/workspace/src/external/api.ts
+++ b/workspace/src/external/api.ts
@@ -3,10 +3,10 @@ import {
   AccountAddressInput,
   Aptos,
   AptosConfig,
+  Ed25519Account,
   Network,
 } from "@aptos-labs/ts-sdk";
 import { publishPackageTask } from "../tasks/publish";
-import { compilePackageTask } from "../tasks/compile";
 import { describe as MochaDescribe } from "mocha";
 
 const aptosConfig = new AptosConfig({ network: Network.LOCAL });
@@ -25,15 +25,25 @@ export const generateTestAccount = async () => {
 };
 
 /**
- * API endpoint to publish a move package, this process compiles and publishes the contract
+ * Publish a package to the Aptos blockchain
+ *
+ * @param args.publisher - The publisher of the package
+ * @param args.namedAddresses - The named addresses for the Move binary, {namedAddresses: {alice:"0x123",bob:"0x456"}}
+ * @param args.addressName - The named address for compiling and using in the contract, {addressName: "alice"}
+ * @returns The address of the published package
  */
 export const publishPackage = async (args: {
-  publisher: Account;
+  publisher: Ed25519Account;
   namedAddresses: Record<string, AccountAddressInput>;
-}) => {
-  const { publisher, namedAddresses } = args;
-  await compilePackageTask(namedAddresses);
-  await publishPackageTask({ aptos, publisher });
+  addressName: string;
+}): Promise<{ packageObjectAddress: string }> => {
+  const { namedAddresses, addressName, publisher } = args;
+  const packageObjectAddress = await publishPackageTask({
+    publisher,
+    namedAddresses,
+    addressName,
+  });
+  return { packageObjectAddress };
 };
 
 /**

--- a/workspace/src/tasks/publish.ts
+++ b/workspace/src/tasks/publish.ts
@@ -1,29 +1,49 @@
 import path from "path";
 import fs from "fs";
-import { Aptos, Account } from "@aptos-labs/ts-sdk";
+import {
+  Ed25519Account,
+  AccountAddress,
+  AccountAddressInput,
+  NetworkToNodeAPI,
+  Network,
+} from "@aptos-labs/ts-sdk";
+import { Move } from "@aptos-labs/ts-sdk/dist/common/cli/index.js";
 import { getUserConfigContractDir } from "../internal/utils/userConfig";
 
+/**
+ * Publish a package to the Aptos blockchain
+ * @returns The address of the published package
+ */
 export const publishPackageTask = async (args: {
-  aptos: Aptos;
-  publisher: Account;
-}) => {
-  const { aptos, publisher } = args;
+  publisher: Ed25519Account;
+  namedAddresses: Record<string, AccountAddressInput>;
+  addressName: string;
+}): Promise<string> => {
+  const { publisher, namedAddresses, addressName } = args;
 
-  const { metadataBytes, byteCode } = await getPackageBytesToPublish();
+  // transform AccountAddressInput to AccountAddress type
+  const transformedAddresses: Record<string, AccountAddress> = {};
 
-  // Publish move package to chain
-  const transaction = await aptos.publishPackageTransaction({
-    account: publisher.accountAddress,
-    metadataBytes,
-    moduleBytecode: byteCode,
+  for (const key in namedAddresses) {
+    if (namedAddresses.hasOwnProperty(key)) {
+      transformedAddresses[key] = AccountAddress.from(namedAddresses[key]);
+    }
+  }
+
+  // get the configured contract dir
+  const contractDir = getUserConfigContractDir();
+
+  const response = await new Move().createObjectAndPublishPackage({
+    packageDirectoryPath: contractDir,
+    addressName,
+    namedAddresses: transformedAddresses,
+    extraArguments: [
+      "--assume-yes",
+      `--private-key=${publisher.privateKey}`,
+      `--url=${NetworkToNodeAPI[Network.LOCAL]}`,
+    ],
   });
-
-  const pendingTransaction = await aptos.signAndSubmitTransaction({
-    signer: publisher,
-    transaction,
-  });
-
-  await aptos.waitForTransaction({ transactionHash: pendingTransaction.hash });
+  return response.objectAddress;
 };
 
 /**


### PR DESCRIPTION
Instead of publishing the move package under a resource account, workspace publishes the package under an object address as this is the recommended way by Aptos