### PR TITLE
Add `move-unit-test` run task

### DIFF
--- a/workspace/package-lock.json
+++ b/workspace/package-lock.json
@@ -14,6 +14,7 @@
         "fs-extra": "^7.0.1",
         "mocha": "^10.7.0",
         "prompts": "^2.4.2",
+        "toml": "^3.0.0",
         "tree-kill": "1.2.2",
         "tsconfig-paths": "^4.2.0"
       },
@@ -4286,6 +4287,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "node_modules/tr46": {
       "version": "1.0.1",

--- a/workspace/package.json
+++ b/workspace/package.json
@@ -26,6 +26,7 @@
     "fs-extra": "^7.0.1",
     "mocha": "^10.7.0",
     "prompts": "^2.4.2",
+    "toml": "^3.0.0",
     "tree-kill": "1.2.2",
     "tsconfig-paths": "^4.2.0"
   },

--- a/workspace/src/internal/cli.ts
+++ b/workspace/src/internal/cli.ts
@@ -2,6 +2,7 @@ import { program } from "commander";
 import prompts from "prompts";
 
 import { test, init, genAbi } from "../tasks";
+import { moveUnitTestTask } from "../tasks/unit-test";
 
 program
   .command("init")
@@ -22,6 +23,13 @@ program
       },
     ]);
     await init(result);
+  });
+
+program
+  .command("move-unit-test")
+  .description("Run Move unit tests")
+  .action(async () => {
+    await moveUnitTestTask();
   });
 
 program
@@ -47,7 +55,7 @@ program
 
 program
   .command("test")
-  .description("Run unit tests")
+  .description("Run integration tests")
   .option(
     "-t, --timeout <treshold>",
     "Specify test timeout threshold (in milliseconds) "

--- a/workspace/src/tasks/unit-test.ts
+++ b/workspace/src/tasks/unit-test.ts
@@ -1,23 +1,24 @@
 import { Move } from "@aptos-labs/ts-sdk/dist/common/cli/index.js";
+import fs from "fs";
+import toml from "toml";
 import { getUserConfigContractDir } from "../internal/utils/userConfig";
-import { AccountAddress, AccountAddressInput } from "@aptos-labs/ts-sdk";
 
-export const moveUnitTestTask = async (
-  namedAddresses: Record<string, AccountAddressInput>
-) => {
-  // transform AccountAddressInput to AccountAddress type
-  const transformedAddresses: Record<string, AccountAddress> = {};
-
-  for (const key in namedAddresses) {
-    if (namedAddresses.hasOwnProperty(key)) {
-      transformedAddresses[key] = AccountAddress.from(namedAddresses[key]);
-    }
-  }
+export const moveUnitTestTask = async () => {
   // get the configured contract dir
   const contractDir = getUserConfigContractDir();
+  // read the Move.toml file
+  var str = fs.readFileSync(contractDir + "/Move.toml", "utf-8");
+  // parse the Move.toml file and extract the named addresses
+  const namedAddresses = toml.parse(str).addresses;
+
+  // generate random addresses for the named addresses
+  Object.keys(namedAddresses).forEach((key) => {
+    let hex = Math.floor(Math.random() * 0xfff + 0x100).toString(16);
+    namedAddresses[key] = `0x${hex}`; // You can assign any value you want here
+  });
 
   await new Move().test({
     packageDirectoryPath: contractDir,
-    namedAddresses: transformedAddresses,
+    namedAddresses,
   });
 };


### PR DESCRIPTION
Add `npx aptos-workspace move-unit-test`. This command will run the contract unit tests. It assigns random named addresses during task run

```
npx aptos-workspace move-unit-test

Previously installed CLI version 4.2.3, checking for updates
CLI is up to date
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING boilerplate_template
warning: unused alias
  ┌─ contract/sources/module.move:3:26
  │
3 │     use aptos_framework::account;
  │                          ^^^^^^^ Unused 'use' of alias 'account'. Consider removing it

Running Move unit tests
[ PASS    ] 0xebe::todolist::account_can_not_update_task
[ PASS    ] 0xebe::todolist::test_flow
Test result: OK. Total tests: 2; passed: 2; failed: 0
{
  "Result": "Success"
}
```