### PR TITLE
Introduce user `verbose` config and hide/show server logs based on it

### DIFF
--- a/workspace/src/external/types.ts
+++ b/workspace/src/external/types.ts
@@ -1,4 +1,5 @@
 export type WorkspaceUserConfig = {
   // The directory where you store your Move package
   contractDir: string;
+  verbose?: boolean;
 };

--- a/workspace/src/internal/node.ts
+++ b/workspace/src/internal/node.ts
@@ -3,6 +3,7 @@ import kill from "tree-kill";
 import * as readline from "readline";
 import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
 import { NodeInfo } from "./utils/types";
+import { getUserConfigVerbose } from "./utils/userConfig";
 
 async function sleep(timeMs: number): Promise<null> {
   return new Promise((resolve) => {
@@ -28,6 +29,8 @@ export class TestNode {
   public static async spawn(): Promise<TestNode> {
     const id = generateRandomId(4);
 
+    const configVerbose = getUserConfigVerbose();
+
     const cliCommand = "aptos-workspace-server";
     const cliArgs: string[] = [];
 
@@ -50,7 +53,9 @@ export class TestNode {
       }, this.TIMEOUT_SECONDS * 1000); // 30 seconds timeout
 
       rl.on("line", (line: string) => {
-        console.log(`[NODE ${id}] ${line}`);
+        if (configVerbose) {
+          console.log(`[NODE ${id}] ${line}`);
+        }
 
         const pattern =
           /Node API is ready. Endpoint:.+:(\d+)|Faucet is ready. Endpoint:.+:(\d+)|Indexer API is ready. Endpoint:.+:(\d+)/g;

--- a/workspace/src/internal/utils/userConfig.ts
+++ b/workspace/src/internal/utils/userConfig.ts
@@ -43,3 +43,19 @@ export const getUserConfigContractDir = () => {
 
   return configContent.contractDir;
 };
+
+/**
+ * Returns the user `verbose` property value from the workspace.config.* file
+ */
+export const getUserConfigVerbose = () => {
+  const userWorkspaceConfigPath = getUserConfigPath();
+  // check if user's project is a ts project, if so load ts-node
+  if (isTSProject()) {
+    loadTsNode();
+  }
+  const imported = require(userWorkspaceConfigPath);
+  const configContent =
+    imported.default !== undefined ? imported.default : imported;
+
+  return configContent.verbose;
+};

--- a/workspace/src/tasks/compile.ts
+++ b/workspace/src/tasks/compile.ts
@@ -1,6 +1,9 @@
 import { AccountAddressInput, AccountAddress } from "@aptos-labs/ts-sdk";
 import { Move } from "@aptos-labs/ts-sdk/dist/common/cli/index.js";
-import { getUserConfigContractDir } from "../internal/utils/userConfig";
+import {
+  getUserConfigContractDir,
+  getUserConfigVerbose,
+} from "../internal/utils/userConfig";
 
 export const compilePackageTask = async (
   namedAddresses: Record<string, AccountAddressInput>
@@ -15,11 +18,13 @@ export const compilePackageTask = async (
   }
   // get the configured contract dir
   const contractDir = getUserConfigContractDir();
+  const configVerbose = getUserConfigVerbose();
 
   await new Move().buildPublishPayload({
     outputFile: `${contractDir}/test-package.json`,
     packageDirectoryPath: contractDir,
     namedAddresses: transformedAddresses,
     extraArguments: ["--assume-yes", "--skip-fetch-latest-git-deps"],
+    showStdout: configVerbose ?? false,
   });
 };

--- a/workspace/src/tasks/publish.ts
+++ b/workspace/src/tasks/publish.ts
@@ -4,7 +4,10 @@ import {
   AccountAddressInput,
 } from "@aptos-labs/ts-sdk";
 import { Move } from "@aptos-labs/ts-sdk/dist/common/cli/index.js";
-import { getUserConfigContractDir } from "../internal/utils/userConfig";
+import {
+  getUserConfigContractDir,
+  getUserConfigVerbose,
+} from "../internal/utils/userConfig";
 import { workspace } from "../external/workspaceGlobal";
 
 /**
@@ -29,6 +32,7 @@ export const publishPackageTask = async (args: {
 
   // get the configured contract dir
   const contractDir = getUserConfigContractDir();
+  const configVerbose = getUserConfigVerbose();
 
   const response = await new Move().createObjectAndPublishPackage({
     packageDirectoryPath: contractDir,
@@ -39,6 +43,7 @@ export const publishPackageTask = async (args: {
       `--private-key=${publisher.privateKey}`,
       `--url=${workspace.aptos.config.fullnode}`,
     ],
+    showStdout: configVerbose ?? false,
   });
   return response.objectAddress;
 };

--- a/workspace/src/tasks/unit-test.ts
+++ b/workspace/src/tasks/unit-test.ts
@@ -20,5 +20,6 @@ export const moveUnitTestTask = async () => {
   await new Move().test({
     packageDirectoryPath: contractDir,
     namedAddresses,
+    showStdout: false,
   });
 };


### PR DESCRIPTION
Introduce a `verbose` user boolean config, and display workspace server logs based on that config

When `verbose` is disabled
```
  my first test
    ✔ it publishes the contract under the correct address


  todoListWithSurf
    ✔ it creates a new list (207ms)
    ✔ it creates a new task (137ms)
    ✔ it marks task as completed (118ms)


  todoList
    ✔ it publishes the contract under the correct address
    ✔ it creates a new list (156ms)
    ✔ it creates a new task (95ms)
    ✔ it marks task as completed (159ms)
```

When `verbose` is enabled
```
[NODE 8794] Node API is ready. Endpoint: http://127.0.0.1:56828/
[NODE 7557] Node API is ready. Endpoint: http://127.0.0.1:56833/
[NODE 7627] Node API is ready. Endpoint: http://127.0.0.1:56844/
[NODE 7557] Transaction stream is ready. Endpoint: http://127.0.0.1:56834/
[NODE 8794] Transaction stream is ready. Endpoint: http://127.0.0.1:56829/
[NODE 7627] Transaction stream is ready. Endpoint: http://127.0.0.1:56845/
[NODE 7557] Faucet is ready. Endpoint: http://127.0.0.1:56922
[NODE 7557] Indexer API is ready. Endpoint: http://127.0.0.1:0/
[NODE 8794] Faucet is ready. Endpoint: http://127.0.0.1:56925
[NODE 8794] Indexer API is ready. Endpoint: http://127.0.0.1:0/
[NODE 7627] Faucet is ready. Endpoint: http://127.0.0.1:56928
[NODE 7627] Indexer API is ready. Endpoint: http://127.0.0.1:0/
Compiling, may take a little while to download git dependencies...
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
Compiling, may take a little while to download git dependencies...
Compiling, may take a little while to download git dependencies...
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING boilerplate_template
warning[W09001]: unused alias
  ┌─ contract/sources/module.move:3:26
  │
3 │     use aptos_framework::account;
  │                          ^^^^^^^ Unused 'use' of alias 'account'. Consider removing it

INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING boilerplate_template
warning: unused alias
  ┌─ contract/sources/module.move:3:26
  │
3 │     use aptos_framework::account;
  │                          ^^^^^^^ Unused 'use' of alias 'account'. Consider removing it

package size 2532 bytes
Transaction submitted: https://explorer.aptoslabs.com/txn/0xb3ad4fc73cd37c9cf415c3f335d7cdb773ba72d84ecf67655c206d69caab270d
Code was successfully deployed to object address 0x9a160d73602107e8aaa499150b61da723718397d11b3c44554ce740b7d9949ea
warning[W09001]: unused alias
  ┌─ contract/sources/module.move:3:26
  │
3 │     use aptos_framework::account;
  │                          ^^^^^^^ Unused 'use' of alias 'account'. Consider removing it

{
  "Result": "Success"
}

  todoList
    ✔ it publishes the contract under the correct address
    ✔ it creates a new list (350ms)
    ✔ it creates a new task (131ms)
    ✔ it marks task as completed (100ms)

warning: unused alias
  ┌─ contract/sources/module.move:3:26
  │
3 │     use aptos_framework::account;
  │                          ^^^^^^^ Unused 'use' of alias 'account'. Consider removing it

package size 2532 bytes
Transaction submitted: https://explorer.aptoslabs.com/txn/0xf1d715b58579177d85a64b9362a703ba3e98c69beecaf9b94e33c1b29fd8160b
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-core.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING boilerplate_template
Code was successfully deployed to object address 0x5ea3dbb3fa3706dea41546c8257d097953ba593812ae60157f35e6230b0ed795
{
  "Result": "Success"
}

  my first test
    ✔ it publishes the contract under the correct address

warning[W09001]: unused alias
  ┌─ contract/sources/module.move:3:26
  │
3 │     use aptos_framework::account;
  │                          ^^^^^^^ Unused 'use' of alias 'account'. Consider removing it

warning: unused alias
  ┌─ contract/sources/module.move:3:26
  │
3 │     use aptos_framework::account;
  │                          ^^^^^^^ Unused 'use' of alias 'account'. Consider removing it

package size 2532 bytes
Transaction submitted: https://explorer.aptoslabs.com/txn/0x5f097860ba6a1c08473da187fe8397f71e94919235c0b2a8701048086d4b5300
Code was successfully deployed to object address 0xcd1465ff20ba060235735cf5ad38c0fab8032ed727d5ee269960fa3a332286e9
{
  "Result": "Success"
}

  todoListWithSurf
    ✔ it creates a new list (206ms)
    ✔ it creates a new task (96ms)
    ✔ it marks task as completed (138ms)


  8 passing (27s)
```