### PR TITLE
Introduce `getSigners()` function

### DIFF
--- a/examples/js-esm-node-app/tests/my-first-test.js
+++ b/examples/js-esm-node-app/tests/my-first-test.js
@@ -1,21 +1,17 @@
 import { expect } from "chai";
-import {
-  generateTestAccount,
-  publishPackage,
-  workspace,
-} from "@aptos-labs/workspace";
+import { publishPackage, workspace } from "@aptos-labs/workspace";
 
 let objectAddress;
 
 describe("my first test", () => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     // publish the package, getting back the package pbject address
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     // set the object address to the package object address

--- a/examples/js-esm-node-app/tests/todoList.js
+++ b/examples/js-esm-node-app/tests/todoList.js
@@ -1,9 +1,5 @@
 import { expect } from "chai";
-import {
-  generateTestAccount,
-  publishPackage,
-  describe,
-} from "@aptos-labs/workspace";
+import { publishPackage, describe } from "@aptos-labs/workspace";
 import { addNewListTransaction } from "../entry-functions/addNewList.js";
 import { addNewTaskTransaction } from "../entry-functions/addNewTask.js";
 import { completeTaskTransaction } from "../entry-functions/completeTask.js";
@@ -13,12 +9,12 @@ let todoListCreator;
 
 describe("todoList", (aptos) => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     objectAddress = packageObjectAddress;
@@ -33,7 +29,7 @@ describe("todoList", (aptos) => {
   });
 
   it("it creates a new list", async () => {
-    todoListCreator = await generateTestAccount();
+    [todoListCreator] = await getSigners();
     const addNewListTxn = await addNewListTransaction(objectAddress);
 
     const transaction = await aptos.transaction.build.simple({

--- a/examples/js-node-app/tests/my-first-test.js
+++ b/examples/js-node-app/tests/my-first-test.js
@@ -1,20 +1,16 @@
 const expect = require("chai").expect;
-const {
-  generateTestAccount,
-  publishPackage,
-  workspace,
-} = require("@aptos-labs/workspace");
+const { publishPackage, workspace } = require("@aptos-labs/workspace");
 
 let objectAddress;
 
 describe("my first test", () => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     objectAddress = packageObjectAddress;

--- a/examples/js-node-app/tests/todoList.js
+++ b/examples/js-node-app/tests/todoList.js
@@ -1,9 +1,5 @@
 const expect = require("chai").expect;
-const {
-  generateTestAccount,
-  publishPackage,
-  describe,
-} = require("@aptos-labs/workspace");
+const { publishPackage, describe } = require("@aptos-labs/workspace");
 const { addNewListTransaction } = require("../entry-functions/addNewList");
 const { addNewTaskTransaction } = require("../entry-functions/addNewTask");
 const { completeTaskTransaction } = require("../entry-functions/completeTask");
@@ -13,12 +9,12 @@ let todoListCreator;
 
 describe("todoList", (aptos) => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     objectAddress = packageObjectAddress;
@@ -33,7 +29,7 @@ describe("todoList", (aptos) => {
   });
 
   it("it creates a new list", async () => {
-    todoListCreator = await generateTestAccount();
+    [todoListCreator] = await getSigners();
     const addNewListTxn = await addNewListTransaction(objectAddress);
 
     const transaction = await aptos.transaction.build.simple({

--- a/examples/ts-nextjs-app/tests/my-first-test.ts
+++ b/examples/ts-nextjs-app/tests/my-first-test.ts
@@ -1,21 +1,17 @@
 import { expect } from "chai";
-import {
-  generateTestAccount,
-  publishPackage,
-  workspace,
-} from "@aptos-labs/workspace";
+import { getSigners, publishPackage, workspace } from "@aptos-labs/workspace";
 
 let objectAddress: string;
 
 describe("my first test", () => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     // publish the package, getting back the package pbject address
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     // set the object address to the package object address

--- a/examples/ts-nextjs-app/tests/todoList.ts
+++ b/examples/ts-nextjs-app/tests/todoList.ts
@@ -1,9 +1,5 @@
 import { expect } from "chai";
-import {
-  generateTestAccount,
-  publishPackage,
-  workspace,
-} from "@aptos-labs/workspace";
+import { getSigners, publishPackage, workspace } from "@aptos-labs/workspace";
 import { Ed25519Account } from "@aptos-labs/ts-sdk";
 import { addNewListTransaction } from "@/entry-functions/addNewList";
 import { addNewTaskTransaction } from "@/entry-functions/addNewTask";
@@ -14,12 +10,12 @@ let objectAddress: string;
 
 describe("todoList", () => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     objectAddress = packageObjectAddress;
@@ -34,7 +30,7 @@ describe("todoList", () => {
   });
 
   it("it creates a new list", async () => {
-    todoListCreator = await generateTestAccount();
+    [todoListCreator] = await getSigners();
     const addNewListTxn = await addNewListTransaction(objectAddress);
 
     const transaction = await workspace.aptos.transaction.build.simple({

--- a/examples/ts-node-app/tests/my-first-test.ts
+++ b/examples/ts-node-app/tests/my-first-test.ts
@@ -1,21 +1,17 @@
 import { expect } from "chai";
-import {
-  generateTestAccount,
-  publishPackage,
-  workspace,
-} from "@aptos-labs/workspace";
+import { getSigners, publishPackage, workspace } from "@aptos-labs/workspace";
 
 let objectAddress: string;
 
 describe("my first test", () => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     // publish the package, getting back the package pbject address
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     // set the object address to the package object address

--- a/examples/ts-node-app/tests/todoList-with-surf.ts
+++ b/examples/ts-node-app/tests/todoList-with-surf.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import {
   generateTestAccount,
+  getSigners,
   publishPackage,
   workspace,
 } from "@aptos-labs/workspace";
@@ -14,12 +15,12 @@ let surfClient: any;
 
 describe("todoListWithSurf", () => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     objectAddress = packageObjectAddress;

--- a/examples/ts-node-app/tests/todoList.ts
+++ b/examples/ts-node-app/tests/todoList.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import {
   generateTestAccount,
+  getSigners,
   publishPackage,
   workspace,
 } from "@aptos-labs/workspace";
@@ -14,12 +15,12 @@ let objectAddress: string;
 
 describe("todoList", () => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     objectAddress = packageObjectAddress;

--- a/examples/ts-vite-dapp/tests/my-first-test.ts
+++ b/examples/ts-vite-dapp/tests/my-first-test.ts
@@ -1,16 +1,16 @@
 import { expect } from "chai";
-import { generateTestAccount, publishPackage, workspace } from "@aptos-labs/workspace";
+import { getSigners, publishPackage, workspace } from "@aptos-labs/workspace";
 let objectAddress: string;
 
 describe("my first test", () => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     // publish the package, getting back the package pbject address
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     // set the object address to the package object address

--- a/examples/ts-vite-dapp/tests/todoList.ts
+++ b/examples/ts-vite-dapp/tests/todoList.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { generateTestAccount, publishPackage, workspace } from "@aptos-labs/workspace";
+import { getSigners, publishPackage, workspace } from "@aptos-labs/workspace";
 import { Ed25519Account } from "@aptos-labs/ts-sdk";
 import { addNewListTransaction } from "@/entry-functions/addNewList";
 import { addNewTaskTransaction } from "@/entry-functions/addNewTask";
@@ -10,12 +10,12 @@ let objectAddress: string;
 
 describe("todoList", () => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     objectAddress = packageObjectAddress;
@@ -30,7 +30,7 @@ describe("todoList", () => {
   });
 
   it("it creates a new list", async () => {
-    todoListCreator = await generateTestAccount();
+    [todoListCreator] = await getSigners();
     const addNewListTxn = await addNewListTransaction(objectAddress);
 
     const transaction = await workspace.aptos.transaction.build.simple({

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -77,17 +77,17 @@ import {
   Ed25519Account,
 } from "@aptos-labs/ts-sdk";
 
-let publisherAccount: Ed25519Account;
+let signer1: Ed25519Account;
 
 describe("my first test", () => {
   // Optional `before` block to publish a Move package before running tests
   before(function (done) {
     (async () => {
-      publisherAccount = await generateTestAccount();
+      signer1 = await generateTestAccount();
       await publishPackage({
-        publisher: publisherAccount,
+        publisher: signer1,
         namedAddresses: {
-          module_addr: publisherAccount.accountAddress.toString(),
+          module_addr: signer1.accountAddress.toString(),
         },
       });
     })().then(done);
@@ -102,7 +102,7 @@ import { expect } from "chai";
 
 it("it publishes the contract under the correct address", async () => {
   const accountModules = await aptos.getAccountModules({
-    accountAddress: publisherAccount.accountAddress,
+    accountAddress: signer1.accountAddress,
   });
   expect(accountModule).to.have.length.at.least(1);
 });

--- a/workspace/sample-project/js-esm/tests/my-first-test.js
+++ b/workspace/sample-project/js-esm/tests/my-first-test.js
@@ -1,21 +1,17 @@
 import { expect } from "chai";
-import {
-  generateTestAccount,
-  publishPackage,
-  workspace,
-} from "@aptos-labs/workspace";
+import { publishPackage, workspace } from "@aptos-labs/workspace";
 
 let objectAddress;
 
 describe("my first test", () => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     // publish the package, getting back the package pbject address
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     // set the object address to the package object address

--- a/workspace/sample-project/js/tests/my-first-test.js
+++ b/workspace/sample-project/js/tests/my-first-test.js
@@ -1,20 +1,16 @@
 const expect = require("chai").expect;
-const {
-  generateTestAccount,
-  publishPackage,
-  workspace,
-} = require("@aptos-labs/workspace");
+const { publishPackage, workspace } = require("@aptos-labs/workspace");
 
 let objectAddress;
 
 describe("my first test", () => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     objectAddress = packageObjectAddress;

--- a/workspace/sample-project/ts/tests/my-first-test.ts
+++ b/workspace/sample-project/ts/tests/my-first-test.ts
@@ -1,21 +1,17 @@
 import { expect } from "chai";
-import {
-  generateTestAccount,
-  publishPackage,
-  workspace,
-} from "@aptos-labs/workspace";
+import { publishPackage, workspace } from "@aptos-labs/workspace";
 
 let objectAddress: string;
 
 describe("my first test", () => {
   before(async function () {
-    const publisherAccount = await generateTestAccount();
+    const [signer1] = await getSigners();
     // publish the package, getting back the package pbject address
     const { packageObjectAddress } = await publishPackage({
-      publisher: publisherAccount,
+      publisher: signer1,
       addressName: "module_addr",
       namedAddresses: {
-        module_addr: publisherAccount.accountAddress,
+        module_addr: signer1.accountAddress,
       },
     });
     // set the object address to the package object address

--- a/workspace/src/external/api.ts
+++ b/workspace/src/external/api.ts
@@ -8,7 +8,7 @@ import { publishPackageTask } from "../tasks/publish";
 import { workspace } from "./workspaceGlobal";
 
 /**
- * API endpoint to create a test account
+ * API endpoint to create a test Ed25519Account account
  */
 export async function generateTestAccount() {
   const account = Account.generate();
@@ -18,6 +18,21 @@ export async function generateTestAccount() {
     options: { waitForIndexer: false },
   });
   return account;
+}
+
+/**
+ * API endpoint to create and get Ed25519Account signers
+ * @param amount - [optional] The number of signers to create. Set to 1 by default
+ * @returns An array of signers
+ */
+export async function getSigners(
+  amount: number = 1
+): Promise<Ed25519Account[]> {
+  const signersPromises: Promise<Ed25519Account>[] = [];
+  for (let i = 0; i < amount; i++) {
+    signersPromises.push(generateTestAccount());
+  }
+  return await Promise.all(signersPromises);
 }
 
 /**


### PR DESCRIPTION
Introduce `getSigners()` function that accepts a number argument for Workspace to create X number of accounts for a test